### PR TITLE
Add rate limit pauses

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-project_version=0.8
+project_version=0.9.0
 base_connector_version=2.0.5
 config_plugin_version=2.0.4

--- a/src/main/java/com/exclamationlabs/connid/base/ringcentral/driver/rest/RingCentralDriver.java
+++ b/src/main/java/com/exclamationlabs/connid/base/ringcentral/driver/rest/RingCentralDriver.java
@@ -15,10 +15,13 @@ package com.exclamationlabs.connid.base.ringcentral.driver.rest;
 
 import com.exclamationlabs.connid.base.connector.driver.rest.BaseRestDriver;
 import com.exclamationlabs.connid.base.connector.driver.rest.RestFaultProcessor;
+import com.exclamationlabs.connid.base.connector.driver.rest.RestResponseData;
 import com.exclamationlabs.connid.base.ringcentral.model.RingCentralCallQueue;
 import com.exclamationlabs.connid.base.ringcentral.configuration.RingCentralConfiguration;
 import com.exclamationlabs.connid.base.ringcentral.model.user.RingCentralUser;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.Header;
+import org.apache.http.client.methods.HttpRequestBase;
 import org.identityconnectors.framework.common.exceptions.ConnectorException;
 
 import java.util.*;
@@ -28,6 +31,8 @@ public class RingCentralDriver extends BaseRestDriver<RingCentralConfiguration> 
     public static final String API_PATH = "scim/v2/";
     public static final String ACCOUNT_API_PATH = "restapi/v1.0/account/~/";
     public static final String EXTENSION_API_PATH = ACCOUNT_API_PATH + "extension";
+
+    public static Map<String, RingCentralRateLimit> rateLimitMap = new HashMap<>();
 
 
     public RingCentralDriver() {
@@ -69,4 +74,47 @@ public class RingCentralDriver extends BaseRestDriver<RingCentralConfiguration> 
         authenticator = null;
     }
 
+    @Override
+    public <T> RestResponseData<T> executeRequest(HttpRequestBase request, Class<T> returnType, boolean isRetry, int retryCount) {
+        String remaining = null;
+        String group = null;
+        String expiration = null;
+
+        RestResponseData<T> response = super.executeRequest(request, returnType, isRetry, retryCount);
+
+        for(Header header : response.getResponseHeaders()){
+            if(remaining != null && expiration != null && group != null){
+                break;
+            }
+            switch (header.getName()) {
+                case "X-Rate-Limit-Group":
+                    group = header.getValue();
+                    break;
+                case "X-Rate-Limit-Remaining":
+                    remaining = header.getValue();
+                    break;
+                case "X-Rate-Limit-Window":
+                    expiration = header.getValue();
+                    break;
+            }
+        }
+        if(rateLimitMap.containsKey(group)){
+            RingCentralRateLimit rateLimit = rateLimitMap.get(group);
+            rateLimit.setRemaining(remaining);
+            if(expiration == null){
+                expiration = "60";
+            }
+            rateLimit.enqueue(Long.parseLong(expiration));
+        }
+        return response;
+    }
+    protected void rateLimitCheck(String group){
+        RingCentralRateLimit rateLimit = rateLimitMap.get(group);
+        if(rateLimit == null){
+            rateLimit = new RingCentralRateLimit();
+            rateLimitMap.put(group, rateLimit);
+        }else{
+            rateLimit.checkRemaining();
+        }
+    }
 }

--- a/src/main/java/com/exclamationlabs/connid/base/ringcentral/driver/rest/RingCentralRateLimit.java
+++ b/src/main/java/com/exclamationlabs/connid/base/ringcentral/driver/rest/RingCentralRateLimit.java
@@ -1,0 +1,44 @@
+package com.exclamationlabs.connid.base.ringcentral.driver.rest;
+
+import java.time.Instant;
+import java.time.Duration;
+import java.util.LinkedList;
+
+public class RingCentralRateLimit {
+    private LinkedList<Instant> queue = new LinkedList();
+    private String remaining;
+
+    protected void enqueue(long expiration) {
+        clear();
+        checkRemaining();
+        queue.add(Instant.now().plusSeconds(expiration));
+    }
+
+    protected void sleep() throws InterruptedException {
+        if(queue.size() == 0){
+            Thread.sleep(60000);
+        }
+        while(queue.size() > 0 && !Duration.between(Instant.now(),queue.peek()).isNegative()){
+            Thread.sleep(2000);
+        }
+        queue.remove();
+    }
+    private void clear() {
+        while(queue.size() > 0 && Duration.between(Instant.now(),queue.peek()).isNegative()){
+            queue.remove();
+        }
+    }
+
+    protected void setRemaining(String remaining) {
+        this.remaining = remaining;
+    }
+    protected void checkRemaining(){
+        if(remaining.equals("0")){
+            try {
+                sleep();
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/main/java/com/exclamationlabs/connid/base/ringcentral/driver/rest/RingCentralUserInvocator.java
+++ b/src/main/java/com/exclamationlabs/connid/base/ringcentral/driver/rest/RingCentralUserInvocator.java
@@ -39,6 +39,7 @@ public class RingCentralUserInvocator implements DriverInvocator<RingCentralDriv
         driver.executePostRequest(RingCentralDriver.EXTENSION_API_PATH,
                 RingCentralUserExtension.class, userExtension);
 
+        driver.rateLimitCheck("heavy");
         RingCentralUser responseUser = driver.executePostRequest(RingCentralDriver.API_PATH + "Users",
                 RingCentralUser.class, userModel).getResponseObject();
 
@@ -50,8 +51,12 @@ public class RingCentralUserInvocator implements DriverInvocator<RingCentralDriv
 
     @Override
     public void update(RingCentralDriver driver, String userId, RingCentralUser modifiedUser) throws ConnectorException {
+        driver.rateLimitCheck("light");
         RingCentralUser currentUser = getOne(driver, userId, Collections.emptyMap());
         updateCurrentUser(currentUser, modifiedUser);
+
+        driver.rateLimitCheck("heavy");
+
         RingCentralUser responseUser = driver.executePutRequest(RingCentralDriver.API_PATH +
                 "Users/" + userId, RingCentralUser.class, modifiedUser).getResponseObject();
 
@@ -62,14 +67,16 @@ public class RingCentralUserInvocator implements DriverInvocator<RingCentralDriv
 
     @Override
     public void delete(RingCentralDriver driver, String userId) throws ConnectorException {
+        driver.rateLimitCheck("heavy");
         driver.executeDeleteRequest(RingCentralDriver.API_PATH + "Users/" + userId, null);
     }
 
     @Override
     public Set<RingCentralUser> getAll(RingCentralDriver driver, ResultsFilter filter,
                                        ResultsPaginator paginator, Integer max) throws ConnectorException {
+        driver.rateLimitCheck("light");
         if (filter.hasFilter()) {
-            final String FILTER_PART = "?count=999999&filter=userName%20eq%20";
+            final String FILTER_PART = "?count=1000&filter=userName%20eq%20";
             final String FILTER_PART2 = "\"" + filter.getValue() + "\"";
             ListUsersResponse response;
             try {
@@ -83,7 +90,7 @@ public class RingCentralUserInvocator implements DriverInvocator<RingCentralDriv
         } else {
 
             ListUsersResponse response = driver.executeGetRequest(RingCentralDriver.API_PATH +
-                            "Users?count=999999", ListUsersResponse.class,
+                            "Users?count=1000", ListUsersResponse.class,
                     Collections.emptyMap()).getResponseObject();
             return new HashSet<>(response.getUsers());
         }
@@ -92,6 +99,7 @@ public class RingCentralUserInvocator implements DriverInvocator<RingCentralDriv
 
     @Override
     public RingCentralUser getOne(RingCentralDriver driver, String userId, Map<String, Object> map) throws ConnectorException {
+        driver.rateLimitCheck("light");
         return driver.executeGetRequest(
                 RingCentralDriver.API_PATH + "Users/" + userId, RingCentralUser.class, Collections.emptyMap()).getResponseObject();
     }


### PR DESCRIPTION
Implements a queueing mechanism that tracks Instants to prevent exceeding API call rates.
Improvement: CallQueue Lookup by User Extension ID